### PR TITLE
Enable multiline labels in dialog windows

### DIFF
--- a/InteractiveAutomationToolkit/Dialogs/ExceptionDialog.cs
+++ b/InteractiveAutomationToolkit/Dialogs/ExceptionDialog.cs
@@ -9,7 +9,7 @@
 	/// </summary>
 	public class ExceptionDialog : Dialog
 	{
-		private readonly Label exceptionLabel = new Label();
+		private readonly Label exceptionLabel = new Label() { IsMultiline = true };
 		private Exception exception;
 
 		/// <summary>

--- a/InteractiveAutomationToolkit/Dialogs/MessageDialog.cs
+++ b/InteractiveAutomationToolkit/Dialogs/MessageDialog.cs
@@ -9,7 +9,7 @@
 	/// </summary>
 	public class MessageDialog : Dialog
 	{
-		private readonly Label messageLabel = new Label();
+		private readonly Label messageLabel = new Label() { IsMultiline = true };
 
 		/// <summary>
 		/// Initializes a new instance of the <see cref="MessageDialog" /> class without a message.

--- a/InteractiveAutomationToolkit/Dialogs/OkCancelDialog.cs
+++ b/InteractiveAutomationToolkit/Dialogs/OkCancelDialog.cs
@@ -19,7 +19,7 @@
 			OkButton.Style = callToAction == CallToAction.OK ? ButtonStyle.CallToAction : ButtonStyle.None;
 			CancelButton.Style = callToAction == CallToAction.Cancel ? ButtonStyle.CallToAction : ButtonStyle.None;
 
-			AddWidget(new Label(message), 0, 0, 1, 2);
+			AddWidget(new Label(message) { IsMultiline = true }, 0, 0, 1, 2);
 
 			AddWidget(new WhiteSpace(), 1, 0);
 

--- a/InteractiveAutomationToolkit/Dialogs/ProgressDialog.cs
+++ b/InteractiveAutomationToolkit/Dialogs/ProgressDialog.cs
@@ -12,7 +12,7 @@
 	public class ProgressDialog : Dialog
 	{
 		private readonly StringBuilder progress = new StringBuilder();
-		private readonly Label progressLabel = new Label();
+		private readonly Label progressLabel = new Label() { IsMultiline = true };
 
 		/// <summary>
 		/// Initializes a new instance of the <see cref="ProgressDialog"/> class.

--- a/InteractiveAutomationToolkit/Dialogs/YesNoDialog.cs
+++ b/InteractiveAutomationToolkit/Dialogs/YesNoDialog.cs
@@ -18,7 +18,7 @@
 			YesButton.Style = callToAction == CallToAction.Yes ? ButtonStyle.CallToAction : ButtonStyle.None;
 			NoButton.Style = callToAction == CallToAction.No ? ButtonStyle.CallToAction : ButtonStyle.None;
 
-			AddWidget(new Label(message), 0, 0, 1, 2);
+			AddWidget(new Label(message) { IsMultiline = true }, 0, 0, 1, 2);
 
 			AddWidget(new WhiteSpace(), 1, 0);
 


### PR DESCRIPTION
Updated dialog classes to initialize Label controls with IsMultiline = true. This allows messages and exception details to be displayed across multiple lines, improving readability and user experience in ExceptionDialog, MessageDialog, ProgressDialog, OkCancelDialog, and YesNoDialog.