### PR TITLE
Add ContainsOption and TrySelectOption to option widgets

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,6 @@ packages/*
 _git2_*
 **/StyleCop.Cache
 *.DotSettings.user
+# Build output nuget packages
+*.nupkg
+InteractiveAutomationToolkit/C:/

--- a/.gitignore
+++ b/.gitignore
@@ -8,4 +8,5 @@ _git2_*
 *.DotSettings.user
 # Build output nuget packages
 *.nupkg
-InteractiveAutomationToolkit/C:/
+# Stray Windows-style path artifacts created by local build tools
+**/C:/

--- a/InteractiveAutomationToolkit/Components/CheckBoxList.cs
+++ b/InteractiveAutomationToolkit/Components/CheckBoxList.cs
@@ -163,6 +163,18 @@
 
 		/// <inheritdoc/>
 		/// <exception cref="ArgumentNullException">When option is null.</exception>
+		public bool ContainsOption(string option)
+		{
+			if (option == null)
+			{
+				throw new ArgumentNullException(nameof(option));
+			}
+
+			return options.ContainsKey(option);
+		}
+
+		/// <inheritdoc/>
+		/// <exception cref="ArgumentNullException">When option is null.</exception>
 		/// <exception cref="ArgumentException">When the option does not exist.</exception>
 		public void Uncheck(string option)
 		{

--- a/InteractiveAutomationToolkit/Components/DropDown.cs
+++ b/InteractiveAutomationToolkit/Components/DropDown.cs
@@ -151,6 +151,36 @@
 			}
 		}
 
+		/// <inheritdoc/>
+		/// <exception cref="ArgumentNullException">When option is null.</exception>
+		public bool ContainsOption(string option)
+		{
+			if (option == null)
+			{
+				throw new ArgumentNullException(nameof(option));
+			}
+
+			return options.Contains(option);
+		}
+
+		/// <inheritdoc/>
+		/// <exception cref="ArgumentNullException">When option is null.</exception>
+		public bool TrySelectOption(string option)
+		{
+			if (option == null)
+			{
+				throw new ArgumentNullException(nameof(option));
+			}
+
+			if (ContainsOption(option))
+			{
+				Selected = option;
+				return true;
+			}
+
+			return false;
+		}
+
 		/// <inheritdoc	/>
 		protected internal override void LoadResult(IUIResults uiResults, ILogger logger = null)
 		{

--- a/InteractiveAutomationToolkit/Components/Generics/GenericCheckBoxList.cs
+++ b/InteractiveAutomationToolkit/Components/Generics/GenericCheckBoxList.cs
@@ -145,6 +145,28 @@
 		}
 
 		/// <inheritdoc/>
+		public bool ContainsOption(Option<T> option)
+		{
+			if (option == null)
+			{
+				throw new ArgumentNullException(nameof(option));
+			}
+
+			return checkBoxListOptions.ContainsKey(option);
+		}
+
+		/// <inheritdoc/>
+		public bool ContainsOption(T value)
+		{
+			if (value == null)
+			{
+				throw new ArgumentNullException(nameof(value));
+			}
+
+			return checkBoxListOptions.Keys.Any(x => Object.Equals(x.Value, value));
+		}
+
+		/// <inheritdoc/>
 		/// <exception cref="ArgumentNullException">When option is null.</exception>
 		/// <exception cref="ArgumentException">When the option does not exist.</exception>
 		public void Check(Option<T> option)

--- a/InteractiveAutomationToolkit/Components/Generics/GenericCheckBoxList.cs
+++ b/InteractiveAutomationToolkit/Components/Generics/GenericCheckBoxList.cs
@@ -158,11 +158,6 @@
 		/// <inheritdoc/>
 		public bool ContainsOption(T value)
 		{
-			if (value == null)
-			{
-				throw new ArgumentNullException(nameof(value));
-			}
-
 			return checkBoxListOptions.Keys.Any(x => Object.Equals(x.Value, value));
 		}
 

--- a/InteractiveAutomationToolkit/Components/Generics/GenericDropDown.cs
+++ b/InteractiveAutomationToolkit/Components/Generics/GenericDropDown.cs
@@ -245,26 +245,14 @@
 		}
 
 		/// <inheritdoc/>
-		/// <exception cref="ArgumentNullException">When value is null.</exception>
 		public bool ContainsOption(T value)
 		{
-			if (value == null)
-			{
-				throw new ArgumentNullException(nameof(value));
-			}
-
 			return dropDownOptions.Any(x => Object.Equals(x.Value, value));
 		}
 
 		/// <inheritdoc/>
-		/// <exception cref="ArgumentNullException">When value is null.</exception>
 		public bool TrySelectOption(T value)
 		{
-			if (value == null)
-			{
-				throw new ArgumentNullException(nameof(value));
-			}
-
 			if (ContainsOption(value))
 			{
 				Selected = value;

--- a/InteractiveAutomationToolkit/Components/Generics/GenericDropDown.cs
+++ b/InteractiveAutomationToolkit/Components/Generics/GenericDropDown.cs
@@ -232,6 +232,66 @@
 			}
 		}
 
+		/// <inheritdoc/>
+		/// <exception cref="ArgumentNullException">When option is null.</exception>
+		public bool ContainsOption(Option<T> option)
+		{
+			if (option == null)
+			{
+				throw new ArgumentNullException(nameof(option));
+			}
+
+			return dropDownOptions.Contains(option);
+		}
+
+		/// <inheritdoc/>
+		/// <exception cref="ArgumentNullException">When value is null.</exception>
+		public bool ContainsOption(T value)
+		{
+			if (value == null)
+			{
+				throw new ArgumentNullException(nameof(value));
+			}
+
+			return dropDownOptions.Any(x => Object.Equals(x.Value, value));
+		}
+
+		/// <inheritdoc/>
+		/// <exception cref="ArgumentNullException">When value is null.</exception>
+		public bool TrySelectOption(T value)
+		{
+			if (value == null)
+			{
+				throw new ArgumentNullException(nameof(value));
+			}
+
+			if (ContainsOption(value))
+			{
+				Selected = value;
+				return true;
+			}
+
+			return false;
+		}
+
+		/// <inheritdoc/>
+		/// <exception cref="ArgumentNullException">When option is null.</exception>
+		public bool TrySelectOption(Option<T> option)
+		{
+			if (option == null)
+			{
+				throw new ArgumentNullException(nameof(option));
+			}
+
+			if (ContainsOption(option))
+			{
+				SelectedOption = option;
+				return true;
+			}
+
+			return false;
+		}
+
 		/// <inheritdoc	/>
 		protected internal override void LoadResult(IUIResults uiResults, ILogger logger = null)
 		{

--- a/InteractiveAutomationToolkit/Components/Generics/GenericRadioButtonList.cs
+++ b/InteractiveAutomationToolkit/Components/Generics/GenericRadioButtonList.cs
@@ -253,23 +253,12 @@
 		/// <inheritdoc/>
 		public bool ContainsOption(T value)
 		{
-			if (value == null)
-			{
-				throw new ArgumentNullException(nameof(value));
-			}
-
 			return radioButtonListOptions.Any(x => Object.Equals(x.Value, value));
 		}
 
 		/// <inheritdoc/>
-		/// <exception cref="ArgumentNullException">When value is null.</exception>
 		public bool TrySelectOption(T value)
 		{
-			if (value == null)
-			{
-				throw new ArgumentNullException(nameof(value));
-			}
-
 			if (ContainsOption(value))
 			{
 				Selected = value;

--- a/InteractiveAutomationToolkit/Components/Generics/GenericRadioButtonList.cs
+++ b/InteractiveAutomationToolkit/Components/Generics/GenericRadioButtonList.cs
@@ -239,6 +239,64 @@
 			SetOptions(options.Select(x => new Option<T>(x)));
 		}
 
+		/// <inheritdoc/>
+		public bool ContainsOption(Option<T> option)
+		{
+			if (option == null)
+			{
+				throw new ArgumentNullException(nameof(option));
+			}
+
+			return radioButtonListOptions.Contains(option);
+		}
+
+		/// <inheritdoc/>
+		public bool ContainsOption(T value)
+		{
+			if (value == null)
+			{
+				throw new ArgumentNullException(nameof(value));
+			}
+
+			return radioButtonListOptions.Any(x => Object.Equals(x.Value, value));
+		}
+
+		/// <inheritdoc/>
+		/// <exception cref="ArgumentNullException">When value is null.</exception>
+		public bool TrySelectOption(T value)
+		{
+			if (value == null)
+			{
+				throw new ArgumentNullException(nameof(value));
+			}
+
+			if (ContainsOption(value))
+			{
+				Selected = value;
+				return true;
+			}
+
+			return false;
+		}
+
+		/// <inheritdoc/>
+		/// <exception cref="ArgumentNullException">When option is null.</exception>
+		public bool TrySelectOption(Option<T> option)
+		{
+			if (option == null)
+			{
+				throw new ArgumentNullException(nameof(option));
+			}
+
+			if (ContainsOption(option))
+			{
+				SelectedOption = option;
+				return true;
+			}
+
+			return false;
+		}
+
 		/// <inheritdoc	/>
 		protected internal override void LoadResult(IUIResults uiResults, ILogger logger = null)
 		{

--- a/InteractiveAutomationToolkit/Components/Interfaces/IDropDown.cs
+++ b/InteractiveAutomationToolkit/Components/Interfaces/IDropDown.cs
@@ -9,6 +9,11 @@
 		/// Gets or sets the currently selected option as a string.
 		/// </summary>
 		string Selected { get; set; }
+
+		/// <summary>
+		/// Attempts to select the specified option. If the option does not exist in the collection, the selection remains unchanged.
+		/// </summary>
+		bool TrySelectOption(string option);
 	}
 
 	/// <summary>
@@ -26,6 +31,16 @@
 		/// Gets or sets the value of the currently selected option.
 		/// </summary>
 		T Selected { get; set; }
+
+		/// <summary>
+		/// Attempts to select the specified option. If the option does not exist in the collection, the selection remains unchanged.
+		/// </summary>
+		bool TrySelectOption(T value);
+
+		/// <summary>
+		/// Attempts to select the specified option. If the option does not exist in the collection, the selection remains unchanged.
+		/// </summary>
+		bool TrySelectOption(Option<T> option);
 	}
 
 }

--- a/InteractiveAutomationToolkit/Components/Interfaces/IDropDown.cs
+++ b/InteractiveAutomationToolkit/Components/Interfaces/IDropDown.cs
@@ -13,6 +13,8 @@
 		/// <summary>
 		/// Attempts to select the specified option. If the option does not exist in the collection, the selection remains unchanged.
 		/// </summary>
+		/// <param name="option">The option to select.</param>
+		/// <returns><c>true</c> if the option was found and selected; otherwise, <c>false</c>.</returns>
 		bool TrySelectOption(string option);
 	}
 
@@ -33,13 +35,17 @@
 		T Selected { get; set; }
 
 		/// <summary>
-		/// Attempts to select the specified option. If the option does not exist in the collection, the selection remains unchanged.
+		/// Attempts to select the option with the specified value. If no matching option exists, the selection remains unchanged.
 		/// </summary>
+		/// <param name="value">The value of the option to select.</param>
+		/// <returns><c>true</c> if a matching option was found and selected; otherwise, <c>false</c>.</returns>
 		bool TrySelectOption(T value);
 
 		/// <summary>
 		/// Attempts to select the specified option. If the option does not exist in the collection, the selection remains unchanged.
 		/// </summary>
+		/// <param name="option">The option to select.</param>
+		/// <returns><c>true</c> if the option was found and selected; otherwise, <c>false</c>.</returns>
 		bool TrySelectOption(Option<T> option);
 	}
 

--- a/InteractiveAutomationToolkit/Components/Interfaces/IOptionWidget.cs
+++ b/InteractiveAutomationToolkit/Components/Interfaces/IOptionWidget.cs
@@ -29,6 +29,13 @@
 		/// </summary>
 		/// <param name="option">The option to remove.</param>
 		void RemoveOption(string option);
+
+		/// <summary>
+		/// Determines whether the specified option exists in the collection.
+		/// </summary>
+		/// <param name="option">The name of the option to locate. Cannot be null.</param>
+		/// <returns>true if the option exists in the collection; otherwise, false.</returns>
+		bool ContainsOption(string option);
 	}
 
 	/// <summary>
@@ -82,6 +89,20 @@
 		/// </summary>
 		/// <param name="value">The value to remove.</param>
 		void RemoveOption(T value);
+
+		/// <summary>
+		/// Determines whether the specified option is present in the collection.
+		/// </summary>
+		/// <param name="option">The option to locate in the collection. Cannot be null.</param>
+		/// <returns>true if the specified option exists in the collection; otherwise, false.</returns>
+		bool ContainsOption(Option<T> option);
+
+		/// <summary>
+		/// Determines whether the specified option exists in the collection.
+		/// </summary>
+		/// <param name="value">The option value to locate in the collection.</param>
+		/// <returns>true if the specified option is found; otherwise, false.</returns>
+		bool ContainsOption(T value);
 	}
 
 }

--- a/InteractiveAutomationToolkit/Components/Interfaces/IRadioButtonList.cs
+++ b/InteractiveAutomationToolkit/Components/Interfaces/IRadioButtonList.cs
@@ -9,6 +9,11 @@
 		///		Currently selected option.
 		/// </summary>
 		string Selected { get; set; }
+
+		/// <summary>
+		/// Attempts to select the specified option. If the option does not exist in the collection, the selection remains unchanged.
+		/// </summary>
+		bool TrySelectOption(string option);
 	}
 
 	/// <summary>
@@ -26,5 +31,15 @@
 		///		Value of the currently selected option.
 		/// </summary>
 		T Selected { get; set; }
+
+		/// <summary>
+		/// Attempts to select the specified option. If the option does not exist in the collection, the selection remains unchanged.
+		/// </summary>
+		bool TrySelectOption(T value);
+
+		/// <summary>
+		/// Attempts to select the specified option. If the option does not exist in the collection, the selection remains unchanged.
+		/// </summary>
+		bool TrySelectOption(Option<T> option);
 	}
 }

--- a/InteractiveAutomationToolkit/Components/Interfaces/IRadioButtonList.cs
+++ b/InteractiveAutomationToolkit/Components/Interfaces/IRadioButtonList.cs
@@ -13,6 +13,8 @@
 		/// <summary>
 		/// Attempts to select the specified option. If the option does not exist in the collection, the selection remains unchanged.
 		/// </summary>
+		/// <param name="option">The option to select.</param>
+		/// <returns><c>true</c> if the option was found and selected; otherwise, <c>false</c>.</returns>
 		bool TrySelectOption(string option);
 	}
 
@@ -33,13 +35,17 @@
 		T Selected { get; set; }
 
 		/// <summary>
-		/// Attempts to select the specified option. If the option does not exist in the collection, the selection remains unchanged.
+		/// Attempts to select the option with the specified value. If no matching option exists, the selection remains unchanged.
 		/// </summary>
+		/// <param name="value">The value of the option to select.</param>
+		/// <returns><c>true</c> if a matching option was found and selected; otherwise, <c>false</c>.</returns>
 		bool TrySelectOption(T value);
 
 		/// <summary>
 		/// Attempts to select the specified option. If the option does not exist in the collection, the selection remains unchanged.
 		/// </summary>
+		/// <param name="option">The option to select.</param>
+		/// <returns><c>true</c> if the option was found and selected; otherwise, <c>false</c>.</returns>
 		bool TrySelectOption(Option<T> option);
 	}
 }

--- a/InteractiveAutomationToolkit/Components/RadioButtonList.cs
+++ b/InteractiveAutomationToolkit/Components/RadioButtonList.cs
@@ -146,6 +146,35 @@
 			}
 		}
 
+		/// <inheritdoc/>
+		public bool ContainsOption(string option)
+		{
+			if (option == null)
+			{
+				throw new ArgumentNullException(nameof(option));
+			}
+
+			return options.Contains(option);
+		}
+
+		/// <inheritdoc/>
+		/// <exception cref="ArgumentNullException">When option is null.</exception>
+		public bool TrySelectOption(string option)
+		{
+			if (option == null)
+			{
+				throw new ArgumentNullException(nameof(option));
+			}
+
+			if (ContainsOption(option))
+			{
+				Selected = option;
+				return true;
+			}
+
+			return false;
+		}
+
 		/// <inheritdoc	/>
 		protected internal override void LoadResult(IUIResults uiResults, ILogger logger = null)
 		{

--- a/InteractiveAutomationToolkitTests/CheckBoxListTests.cs
+++ b/InteractiveAutomationToolkitTests/CheckBoxListTests.cs
@@ -1,0 +1,25 @@
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Skyline.DataMiner.Utils.InteractiveAutomationScript;
+
+namespace InteractiveAutomationToolkitTests
+{
+    [TestClass]
+    public class CheckBoxListTests
+    {
+        [TestMethod]
+        public void ContainsOption_ExistingOption_ReturnsTrue()
+        {
+            var checkBoxList = new CheckBoxList(new[] { "a", "b", "c" });
+
+            Assert.IsTrue(checkBoxList.ContainsOption("b"));
+        }
+
+        [TestMethod]
+        public void ContainsOption_MissingOption_ReturnsFalse()
+        {
+            var checkBoxList = new CheckBoxList(new[] { "a", "b", "c" });
+
+            Assert.IsFalse(checkBoxList.ContainsOption("z"));
+        }
+    }
+}

--- a/InteractiveAutomationToolkitTests/DropDownTests.cs
+++ b/InteractiveAutomationToolkitTests/DropDownTests.cs
@@ -1,0 +1,47 @@
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Skyline.DataMiner.Utils.InteractiveAutomationScript;
+
+namespace InteractiveAutomationToolkitTests
+{
+    [TestClass]
+    public class DropDownTests
+    {
+        [TestMethod]
+        public void ContainsOption_ExistingOption_ReturnsTrue()
+        {
+            var dropDown = new DropDown(new[] { "a", "b", "c" });
+
+            Assert.IsTrue(dropDown.ContainsOption("b"));
+        }
+
+        [TestMethod]
+        public void ContainsOption_MissingOption_ReturnsFalse()
+        {
+            var dropDown = new DropDown(new[] { "a", "b", "c" });
+
+            Assert.IsFalse(dropDown.ContainsOption("z"));
+        }
+
+        [TestMethod]
+        public void TrySelectOption_ExistingOption_SelectsAndReturnsTrue()
+        {
+            var dropDown = new DropDown(new[] { "a", "b", "c" }, "a");
+
+            bool result = dropDown.TrySelectOption("c");
+
+            Assert.IsTrue(result);
+            Assert.AreEqual("c", dropDown.Selected);
+        }
+
+        [TestMethod]
+        public void TrySelectOption_MissingOption_ReturnsFalseAndKeepsSelection()
+        {
+            var dropDown = new DropDown(new[] { "a", "b", "c" }, "a");
+
+            bool result = dropDown.TrySelectOption("z");
+
+            Assert.IsFalse(result);
+            Assert.AreEqual("a", dropDown.Selected);
+        }
+    }
+}

--- a/InteractiveAutomationToolkitTests/GenericCheckBoxListTests.cs
+++ b/InteractiveAutomationToolkitTests/GenericCheckBoxListTests.cs
@@ -454,5 +454,46 @@ namespace InteractiveAutomationToolkitTests
 
             Assert.IsTrue(checkboxlist.CheckedOptions.Single().IsEmpty);
         }
+
+        [TestMethod]
+        public void ContainsOption_ByValue_ExistingOption_ReturnsTrue()
+        {
+            var checkboxlist = new CheckBoxList<int>(new[] { 1, 2, 3 });
+
+            Assert.IsTrue(checkboxlist.ContainsOption(2));
+        }
+
+        [TestMethod]
+        public void ContainsOption_ByValue_MissingOption_ReturnsFalse()
+        {
+            var checkboxlist = new CheckBoxList<int>(new[] { 1, 2, 3 });
+
+            Assert.IsFalse(checkboxlist.ContainsOption(99));
+        }
+
+        [TestMethod]
+        public void ContainsOption_ByOption_ExistingOption_ReturnsTrue()
+        {
+            var option = new Option<int>("two", 2);
+            var checkboxlist = new CheckBoxList<int>(new[] { new Option<int>("one", 1), option });
+
+            Assert.IsTrue(checkboxlist.ContainsOption(option));
+        }
+
+        [TestMethod]
+        public void ContainsOption_ByOption_MissingOption_ReturnsFalse()
+        {
+            var checkboxlist = new CheckBoxList<int>(new[] { new Option<int>("one", 1) });
+
+            Assert.IsFalse(checkboxlist.ContainsOption(new Option<int>("two", 2)));
+        }
+
+        [TestMethod]
+        public void ContainsOption_ByOption_NullOption_ThrowsArgumentNullException()
+        {
+            var checkboxlist = new CheckBoxList<int>(new[] { 1, 2 });
+
+            Assert.ThrowsExactly<ArgumentNullException>(() => checkboxlist.ContainsOption((Option<int>)null));
+        }
     }
 }

--- a/InteractiveAutomationToolkitTests/GenericDropDownTests.cs
+++ b/InteractiveAutomationToolkitTests/GenericDropDownTests.cs
@@ -210,5 +210,101 @@ namespace InteractiveAutomationToolkitTests
             Assert.IsNull(dropDown.Selected);
             Assert.IsTrue(dropDown.SelectedOption.IsEmpty);
         }
+
+        [TestMethod]
+        public void ContainsOption_ByValue_ExistingOption_ReturnsTrue()
+        {
+            var dropDown = new DropDown<int>(new[] { 1, 2, 3 });
+
+            Assert.IsTrue(dropDown.ContainsOption(2));
+        }
+
+        [TestMethod]
+        public void ContainsOption_ByValue_MissingOption_ReturnsFalse()
+        {
+            var dropDown = new DropDown<int>(new[] { 1, 2, 3 });
+
+            Assert.IsFalse(dropDown.ContainsOption(99));
+        }
+
+        [TestMethod]
+        public void ContainsOption_ByOption_ExistingOption_ReturnsTrue()
+        {
+            var option = new Option<int>("two", 2);
+            var dropDown = new DropDown<int>(new[] { new Option<int>("one", 1), option });
+
+            Assert.IsTrue(dropDown.ContainsOption(option));
+        }
+
+        [TestMethod]
+        public void ContainsOption_ByOption_MissingOption_ReturnsFalse()
+        {
+            var dropDown = new DropDown<int>(new[] { new Option<int>("one", 1) });
+
+            Assert.IsFalse(dropDown.ContainsOption(new Option<int>("two", 2)));
+        }
+
+        [TestMethod]
+        public void TrySelectOption_ByValue_ExistingOption_SelectsAndReturnsTrue()
+        {
+            var dropDown = new DropDown<int>(new[] { 1, 2, 3 }, 1);
+
+            bool result = dropDown.TrySelectOption(3);
+
+            Assert.IsTrue(result);
+            Assert.AreEqual(3, dropDown.Selected);
+        }
+
+        [TestMethod]
+        public void TrySelectOption_ByValue_MissingOption_ReturnsFalseAndKeepsSelection()
+        {
+            var dropDown = new DropDown<int>(new[] { 1, 2, 3 }, 1);
+
+            bool result = dropDown.TrySelectOption(99);
+
+            Assert.IsFalse(result);
+            Assert.AreEqual(1, dropDown.Selected);
+        }
+
+        [TestMethod]
+        public void TrySelectOption_ByOption_ExistingOption_SelectsAndReturnsTrue()
+        {
+            var option1 = new Option<int>("one", 1);
+            var option2 = new Option<int>("two", 2);
+            var dropDown = new DropDown<int>(new[] { option1, option2 }, option1);
+
+            bool result = dropDown.TrySelectOption(option2);
+
+            Assert.IsTrue(result);
+            Assert.AreEqual(option2, dropDown.SelectedOption);
+        }
+
+        [TestMethod]
+        public void TrySelectOption_ByOption_MissingOption_ReturnsFalseAndKeepsSelection()
+        {
+            var option1 = new Option<int>("one", 1);
+            var dropDown = new DropDown<int>(new[] { option1 }, option1);
+
+            bool result = dropDown.TrySelectOption(new Option<int>("missing", 99));
+
+            Assert.IsFalse(result);
+            Assert.AreEqual(option1, dropDown.SelectedOption);
+        }
+
+        [TestMethod]
+        public void ContainsOption_ByOption_NullOption_ThrowsArgumentNullException()
+        {
+            var dropDown = new DropDown<int>(new[] { 1, 2 });
+
+            Assert.ThrowsExactly<ArgumentNullException>(() => dropDown.ContainsOption((Option<int>)null));
+        }
+
+        [TestMethod]
+        public void TrySelectOption_ByOption_NullOption_ThrowsArgumentNullException()
+        {
+            var dropDown = new DropDown<int>(new[] { 1, 2 });
+
+            Assert.ThrowsExactly<ArgumentNullException>(() => dropDown.TrySelectOption((Option<int>)null));
+        }
     }
 }

--- a/InteractiveAutomationToolkitTests/GenericRadioButtonListTests.cs
+++ b/InteractiveAutomationToolkitTests/GenericRadioButtonListTests.cs
@@ -240,5 +240,101 @@ namespace InteractiveAutomationToolkitTests
             Assert.IsNull(radioButtonList.Selected);
             Assert.IsTrue(radioButtonList.SelectedOption.IsEmpty);
         }
+
+        [TestMethod]
+        public void ContainsOption_ByValue_ExistingOption_ReturnsTrue()
+        {
+            var radioButtonList = new RadioButtonList<int>(new[] { 1, 2, 3 });
+
+            Assert.IsTrue(radioButtonList.ContainsOption(2));
+        }
+
+        [TestMethod]
+        public void ContainsOption_ByValue_MissingOption_ReturnsFalse()
+        {
+            var radioButtonList = new RadioButtonList<int>(new[] { 1, 2, 3 });
+
+            Assert.IsFalse(radioButtonList.ContainsOption(99));
+        }
+
+        [TestMethod]
+        public void ContainsOption_ByOption_ExistingOption_ReturnsTrue()
+        {
+            var option = new Option<int>("two", 2);
+            var radioButtonList = new RadioButtonList<int>(new[] { new Option<int>("one", 1), option });
+
+            Assert.IsTrue(radioButtonList.ContainsOption(option));
+        }
+
+        [TestMethod]
+        public void ContainsOption_ByOption_MissingOption_ReturnsFalse()
+        {
+            var radioButtonList = new RadioButtonList<int>(new[] { new Option<int>("one", 1) });
+
+            Assert.IsFalse(radioButtonList.ContainsOption(new Option<int>("two", 2)));
+        }
+
+        [TestMethod]
+        public void TrySelectOption_ByValue_ExistingOption_SelectsAndReturnsTrue()
+        {
+            var radioButtonList = new RadioButtonList<int>(new[] { 1, 2, 3 }, 1);
+
+            bool result = radioButtonList.TrySelectOption(3);
+
+            Assert.IsTrue(result);
+            Assert.AreEqual(3, radioButtonList.Selected);
+        }
+
+        [TestMethod]
+        public void TrySelectOption_ByValue_MissingOption_ReturnsFalseAndKeepsSelection()
+        {
+            var radioButtonList = new RadioButtonList<int>(new[] { 1, 2, 3 }, 1);
+
+            bool result = radioButtonList.TrySelectOption(99);
+
+            Assert.IsFalse(result);
+            Assert.AreEqual(1, radioButtonList.Selected);
+        }
+
+        [TestMethod]
+        public void TrySelectOption_ByOption_ExistingOption_SelectsAndReturnsTrue()
+        {
+            var option1 = new Option<int>("one", 1);
+            var option2 = new Option<int>("two", 2);
+            var radioButtonList = new RadioButtonList<int>(new[] { option1, option2 }, option1);
+
+            bool result = radioButtonList.TrySelectOption(option2);
+
+            Assert.IsTrue(result);
+            Assert.AreEqual(option2, radioButtonList.SelectedOption);
+        }
+
+        [TestMethod]
+        public void TrySelectOption_ByOption_MissingOption_ReturnsFalseAndKeepsSelection()
+        {
+            var option1 = new Option<int>("one", 1);
+            var radioButtonList = new RadioButtonList<int>(new[] { option1 }, option1);
+
+            bool result = radioButtonList.TrySelectOption(new Option<int>("missing", 99));
+
+            Assert.IsFalse(result);
+            Assert.AreEqual(option1, radioButtonList.SelectedOption);
+        }
+
+        [TestMethod]
+        public void ContainsOption_ByOption_NullOption_ThrowsArgumentNullException()
+        {
+            var radioButtonList = new RadioButtonList<int>(new[] { 1, 2 });
+
+            Assert.ThrowsExactly<ArgumentNullException>(() => radioButtonList.ContainsOption((Option<int>)null));
+        }
+
+        [TestMethod]
+        public void TrySelectOption_ByOption_NullOption_ThrowsArgumentNullException()
+        {
+            var radioButtonList = new RadioButtonList<int>(new[] { 1, 2 });
+
+            Assert.ThrowsExactly<ArgumentNullException>(() => radioButtonList.TrySelectOption((Option<int>)null));
+        }
     }
 }

--- a/InteractiveAutomationToolkitTests/RadioButtonListTests.cs
+++ b/InteractiveAutomationToolkitTests/RadioButtonListTests.cs
@@ -50,5 +50,43 @@ namespace InteractiveAutomationToolkitTests
 
             Assert.IsNull(radioButtonList.Selected);
         }
+
+        [TestMethod]
+        public void ContainsOption_ExistingOption_ReturnsTrue()
+        {
+            var radioButtonList = new RadioButtonList(new[] { "a", "b", "c" });
+
+            Assert.IsTrue(radioButtonList.ContainsOption("b"));
+        }
+
+        [TestMethod]
+        public void ContainsOption_MissingOption_ReturnsFalse()
+        {
+            var radioButtonList = new RadioButtonList(new[] { "a", "b", "c" });
+
+            Assert.IsFalse(radioButtonList.ContainsOption("z"));
+        }
+
+        [TestMethod]
+        public void TrySelectOption_ExistingOption_SelectsAndReturnsTrue()
+        {
+            var radioButtonList = new RadioButtonList(new[] { "a", "b", "c" }, "a");
+
+            bool result = radioButtonList.TrySelectOption("c");
+
+            Assert.IsTrue(result);
+            Assert.AreEqual("c", radioButtonList.Selected);
+        }
+
+        [TestMethod]
+        public void TrySelectOption_MissingOption_ReturnsFalseAndKeepsSelection()
+        {
+            var radioButtonList = new RadioButtonList(new[] { "a", "b", "c" }, "a");
+
+            bool result = radioButtonList.TrySelectOption("z");
+
+            Assert.IsFalse(result);
+            Assert.AreEqual("a", radioButtonList.Selected);
+        }
     }
 }


### PR DESCRIPTION
Introduce ContainsOption and TrySelectOption methods to dropdown, radio button, and checkbox list widgets (generic and non-generic). These methods allow checking for the existence of options and safely attempting selection. Updated interfaces, implementations, and XML docs to improve API consistency and usability.

AB#41138